### PR TITLE
añadir clases PokeApi.java y ApiClient.java

### DIFF
--- a/app/src/main/java/com/srd14/minipokedexui/ApiClient.java
+++ b/app/src/main/java/com/srd14/minipokedexui/ApiClient.java
@@ -1,0 +1,23 @@
+package com.srd14.minipokedexui;
+
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class ApiClient {
+    private static final String BASE_URL = "https://pokeapi.co/api/v2/";
+    private static Retrofit retrofit = null;
+
+    public static Retrofit getClient() {
+        if (retrofit == null) {
+            retrofit = new Retrofit.Builder()
+                    .baseUrl(BASE_URL)
+                    .addConverterFactory(GsonConverterFactory.create())
+                    .build();
+        }
+        return retrofit;
+    }
+
+    public static PokeApi getPokeApi() {
+        return getClient().create(PokeApi.class);
+    }
+}

--- a/app/src/main/java/com/srd14/minipokedexui/PokeApi.java
+++ b/app/src/main/java/com/srd14/minipokedexui/PokeApi.java
@@ -1,0 +1,10 @@
+package com.srd14.minipokedexui;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+
+public interface PokeApi {
+    @GET("pokemon/{nameOrId}")
+    Call<PokemonResponse> getPokemon(@Path("nameOrId") String nameOrId);
+}


### PR DESCRIPTION
🔧 Paso 6. Interfaz de API y cliente Retrofit
Interfaz de API:

Interfaz Retrofit para consumir PokeAPI
Cliente Retrofit configurado con la URL base
Método para obtener Pokémon por nombre o ID
PokeApi.java y ApiClient.java

// PokeApi.java
import retrofit2.Call;
import retrofit2.http.GET;
import retrofit2.http.Path;

public interface PokeApi {
    @GET("pokemon/{nameOrId}")
    Call<PokemonResponse> getPokemon(@Path("nameOrId") String nameOrId);
}

// ApiClient.java
import retrofit2.Retrofit;
import retrofit2.converter.gson.GsonConverterFactory;

public class ApiClient {
    private static final String BASE_URL = "https://pokeapi.co/api/v2/";
    private static Retrofit retrofit = null;

    public static Retrofit getClient() {
        if (retrofit == null) {
            retrofit = new Retrofit.Builder()
                    .baseUrl(BASE_URL)
                    .addConverterFactory(GsonConverterFactory.create())
                    .build();
        }
        return retrofit;
    }

    public static PokeApi getPokeApi() {
        return getClient().create(PokeApi.class);
    }
}